### PR TITLE
Support for .ms extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ Or again, through grunt-browserify:
 Changelog
 ---------
 
+### 0.1.2
+
+-   Picks up .ms extension
+
 ### 0.1.1
 
 -   Minor README update

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ var
     path = require('path'),
     through = require('through2');
 
-var extensions = ['.hogan', '.mustache'];
+var extensions = ['.hogan', '.mustache', '.ms'];
 
 module.exports = function hoganify (file, options) {
     if (extensions.indexOf(path.extname(file)) === -1) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hoganify",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Browserify transform for precompiling Mustache templates using Hogan",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
`.ms` is also a common mustache one.

I saw your comment in the other pull request to add extensions as passable options but in my case of passing the function as a browserify transform I have no idea how to set those options anyway unless there was some seperate init function e.g.:

```
var bundler = browserify('index.js');
bundler.transform(hoganify);
```
